### PR TITLE
fixed the no space left on device error by changing kma tmp dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,5 @@ kma index -i <your_scheme.fa> -o <your_scheme>
 nextflow run BCCDC-PHL/kma-cgmlst \
   --fastq_input </path/to/fastqs> \
   --scheme </path/to/cgmlst_scheme> \
-  --outdir </path/to/output_dir> \
-  --tmp </path/to/tmp_folder_for_kma_align> 
+  --outdir </path/to/output_dir> 
 ```

--- a/README.md
+++ b/README.md
@@ -25,5 +25,6 @@ kma index -i <your_scheme.fa> -o <your_scheme>
 nextflow run BCCDC-PHL/kma-cgmlst \
   --fastq_input </path/to/fastqs> \
   --scheme </path/to/cgmlst_scheme> \
-  --outdir </path/to/output_dir>  
+  --outdir </path/to/output_dir> \
+  --tmp </path/to/tmp_folder_for_kma_align> 
 ```

--- a/modules/kma_align.nf
+++ b/modules/kma_align.nf
@@ -11,11 +11,6 @@ process kma_align {
     tuple val(sample_id), path("${sample_id}_kma.csv")
 
     script:
-    if (params.tmp){
-       kmaCmd = "kma -tmp ${params.tmp}"
-    } else {
-       kmaCmd = "kma"
-    }
 
     """
     ln -s ${scheme}.comp.b .
@@ -23,7 +18,7 @@ process kma_align {
     ln -s ${scheme}.name .
     ln -s ${scheme}.seq.b .
     
-    ${kmaCmd} \
+    kma \
       -t ${task.cpus} \
       -cge \
       -boot \
@@ -32,7 +27,8 @@ process kma_align {
       -and \
       -o ${sample_id}.kma \
       -t_db ${scheme} \
-      -ipe ${read_1} ${read_2}
+      -ipe ${read_1} ${read_2} \
+      -tmp .
     cat ${sample_id}.kma.res | awk '\$1 ~ /^#/ {print substr(tolower(\$0), 2)}; \$1 ~ !/^#/ {print \$0}' \
       | tr -d ' ' | tr \$'\\t' ',' > ${sample_id}_kma.csv
     """

--- a/modules/kma_align.nf
+++ b/modules/kma_align.nf
@@ -6,17 +6,24 @@ process kma_align {
 
     input:
     tuple val(sample_id), path(read_1), path(read_2), val(scheme)
-
+ 
     output:
     tuple val(sample_id), path("${sample_id}_kma.csv")
 
     script:
+    if (params.tmp){
+       kmaCmd = "kma -tmp ${params.tmp}"
+    } else {
+       kmaCmd = "kma"
+    }
+
     """
     ln -s ${scheme}.comp.b .
     ln -s ${scheme}.length.b .
     ln -s ${scheme}.name .
     ln -s ${scheme}.seq.b .
-    kma \
+    
+    ${kmaCmd} \
       -t ${task.cpus} \
       -cge \
       -boot \

--- a/modules/kma_align.nf
+++ b/modules/kma_align.nf
@@ -6,12 +6,11 @@ process kma_align {
 
     input:
     tuple val(sample_id), path(read_1), path(read_2), val(scheme)
- 
+
     output:
     tuple val(sample_id), path("${sample_id}_kma.csv")
 
     script:
-
     """
     ln -s ${scheme}.comp.b .
     ln -s ${scheme}.length.b .


### PR DESCRIPTION
Fixes #2 

User can specify -tmp for tmp directories for kma, which resolved the error "no space left on device".